### PR TITLE
Fix rotate bug when array is not your example array "@[@1, @2, @3, @4]".

### DIFF
--- a/NSArray+rotate.m
+++ b/NSArray+rotate.m
@@ -9,7 +9,7 @@
     return ^(NSInteger pivot) {
         if (pivot < 0)
             pivot = (int)self.count + pivot;
-        return self.skip(pivot).concat(self.snip(pivot));
+        return self.skip(pivot).concat(self.snip(self.count - pivot));
     };
 }
 


### PR DESCRIPTION
Hi, there is a issue of NSArray+rotate when the array.count != 6. Your test array is just a coincidence in unit test.

id rv = @[@1, @2, @3, @4, @5, @6, @7].rotate(-2);

if (pivot < 0)
    pivot = (int)self.count + pivot;                        // pivot = 7 - 2 = 5
return self.skip(pivot).concat(self.snip(pivot)); 
                                                            before fix: // self.skip(5) ===> @[@6, @7]
                                                                              // self.snip(5) ===> @[@1, @2]
                                                                              // .concat ===> @[@6, @7, @1, @2]  ❌
return self.skip(pivot).concat(self.snip(self.count - pivot)); 
                                                               after fix: // self.skip(5) ===> @[@6, @7]
                                                                              // self.snip(2) ===> @[@1, @2, @3, @4, @5]
                                                                              // .concat ===> @[@6, @7, @1, @2, @3, @4, @5] ✅

So grateful for your YOLOKit that helped me a lot!